### PR TITLE
Fix issue #14 - remove plugins on reload

### DIFF
--- a/pinhook/bot.py
+++ b/pinhook/bot.py
@@ -2,6 +2,7 @@ import imp
 import os
 import ssl
 import time
+import pinhook.plugin
 
 import irc.bot
 
@@ -48,6 +49,8 @@ class Bot(irc.bot.SingleServerIRCBot):
                 setattr(self, a, kwarguments[a])
 
     def load_plugins(self):
+        # clear plugin list to ensure no old plugins remain
+        pinhook.plugin.clear_plugins()
         # ensure plugin folder exists
         if not os.path.exists(self.plugin_dir):
             os.makedirs(self.plugin_dir)

--- a/pinhook/plugin.py
+++ b/pinhook/plugin.py
@@ -21,6 +21,10 @@ def add_plugin(command, func):
     cmds.append({'cmd': command, 'func': func})
 
 
+def clear_plugins():
+    cmds.clear()
+
+
 def register(command):
     def register_for_command(func):
         add_plugin(command, func)


### PR DESCRIPTION
This fix for load_plugins will clear the plugin.cmds list to ensure that
removed plugins don't remain after reloads.