### PR TITLE
Output type as an Enum

### DIFF
--- a/pinhook/bot.py
+++ b/pinhook/bot.py
@@ -222,12 +222,14 @@ class Bot(irc.bot.SingleServerIRCBot):
         for msg in output.msg:
             if len(msg.encode('UTF-8')) > 512:
                 self.logger.error('output message too long: {}'.format(msg))
-            elif output.msg_type == 'message':
+            elif output.msg_type == pinhook.plugin.OutputType.Message:
                 self.logger.debug('output message: {}'.format(msg))
                 c.privmsg(chan, msg)
-            elif output.msg_type == 'action':
+            elif output.msg_type == pinhook.plugin.OutputType.Action:
                 self.logger.debug('output action: {}'.format(msg))
                 c.action(chan, msg)
+            else:
+                self.logger.warning("Unsupported output type '{}'".format(output.msg_type))
             time.sleep(.5)
 
 

--- a/pinhook/plugin.py
+++ b/pinhook/plugin.py
@@ -1,5 +1,13 @@
+from enum import Enum
+
+
 cmds = {}
 lstnrs = {}
+
+
+class OutputType(Enum):
+    Message = 'message'
+    Action = 'action'
 
 
 class Output:
@@ -15,11 +23,11 @@ class Output:
 
 
 def action(msg):
-    return Output('action', msg)
+    return Output(OutputType.Action, msg)
 
 
 def message(msg):
-    return Output('message', msg)
+    return Output(OutputType.Message, msg)
 
 
 def _add_plugin(command, func):

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ AUTHOR = 'M. Hancock'
 # What packages are required for this module to be executed?
 REQUIRED = [
     'irc',
+    'enum34',
 ]
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
Use an Enum class for output types instead of hardcoded strings. This should make maintenance and unit testing easier.

Since enums were added in Python 3.4, this adds a `enum34` requirement to backport it to all supported pinhook versions.

Fixes #32 