### PR TITLE
Make example scripts executable

### DIFF
--- a/examples/irc/dicebot.py
+++ b/examples/irc/dicebot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from pinhook.bot import Bot
 
 ph = Bot(

--- a/examples/twitch/dicebot.py
+++ b/examples/twitch/dicebot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from pinhook.bot import TwitchBot
 
 bot = TwitchBot(


### PR DESCRIPTION
Adds [shebangs](https://en.wikipedia.org/wiki/Shebang_(Unix)) to both example scripts and changes their permissions to make them executable. This allows running the scripts as `./dicebot.py` instead of `python dicebot.py`