### PR TITLE
Add bot as argument for Message class & pass self in calls

### DIFF
--- a/pinhook/bot.py
+++ b/pinhook/bot.py
@@ -37,7 +37,8 @@ class Bot(irc.bot.SingleServerIRCBot):
         self.load_plugins()
 
     class Message:
-        def __init__(self, channel, nick, botnick, ops, logger, action, privmsg, notice, cmd=None, arg=None, text=None, nick_list=None):
+        def __init__(self, bot, channel, nick, botnick, ops, logger, action, privmsg, notice, cmd=None, arg=None, text=None, nick_list=None):
+            self.bot = bot
             self.datetime = datetime.now(timezone.utc)
             self.timestamp = self.datetime.timestamp()
             self.channel = channel
@@ -165,6 +166,7 @@ class Bot(irc.bot.SingleServerIRCBot):
                 else:
                     self.logger.debug('executing {}'.format(cmd))
                     output = pinhook.plugin.cmds[cmd]['run'](self.Message(
+                        bot=self,
                         channel=chan,
                         cmd=cmd,
                         nick_list=nick_list,
@@ -184,6 +186,7 @@ class Bot(irc.bot.SingleServerIRCBot):
                 try:
                     self.logger.debug('whispering to listener: {}'.format(lstnr))
                     listen_output = pinhook.plugin.lstnrs[lstnr](self.Message(
+                        bot=self,
                         channel=chan,
                         text=text,
                         nick_list=nick_list,


### PR DESCRIPTION
Passing the bot object as an argument to the Message class make
the pinhook Bot class more extensible. Now it is easy to inherit and
pass attributes of the inherited class into plugins.

See https://github.com/archangelic/pinhook/issues/59

Example usage:

```python3
from pinhook.bot import Bot
from mybot.nlp.model import Model

class Mybot(Bot):

    def __init__(self, **config):

        super().__init__(**config)

        self.config = config
        self.model = Model()

```

Now I can use my new attribute in a plugin:

```python3
import pinhook

@pinhook.plugin.listener('parser')
def parse(msg):
    return pinhook.plugin.message(msg.bot.model.parse(msg.text))
```