### PR TITLE
Issue #12 - Dynamic enable/disable plugins by filename

### DIFF
--- a/pinhook/bot.py
+++ b/pinhook/bot.py
@@ -14,7 +14,6 @@ irc.client.ServerConnection.buffer_class.errors = 'replace'
 
 class Bot(irc.bot.SingleServerIRCBot):
     def __init__(self, channels, nickname, server, **kwargs):
-        print('local bot initialized')
         self.set_kwargs(**kwargs)
         if self.ssl_required:
             factory = irc.connection.Factory(wrapper=ssl.wrap_socket)

--- a/pinhook/bot.py
+++ b/pinhook/bot.py
@@ -114,6 +114,7 @@ class Bot(irc.bot.SingleServerIRCBot):
                     if name in self.whitelist and name not in self.blacklist:
                         pass
                     if name in self.blacklist and name not in self.whitelist:
+                        self.logger.info('not loading blacklisted plugin {}'.format(name))
                         continue
                     if name not in self.whitelist and name not in self.blacklist:
                         self.whitelist.append(name)


### PR DESCRIPTION
This adds a whitelist and blacklist commands and configuration settings for operators and owners to use respectively. This allows plugins to be enable and disable on the fly.

this will :
- allow ops to add plugin filenames to a whitelist or a blacklist
- remove items from the whitelist when added to the blacklist and vice versa
- enable/disable every command and listener in the plugin file
- allow "whitelist" and "blacklist" kwargs when constructing a Bot
- create a whitelist from loaded plugins if none exists